### PR TITLE
Add basic support for non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ https://htest.dev
 - ✅ **Quick to write**: Most tests only need two properties: `args` and `expect`. No more excuses for not testing your utility functions!
 - ✅ **ESM-first**: Written in ESM from the get-go.
 - ✅ **CLI and browser**: Run your tests in the command line, in the browser, or both.
+- ✅ **CI-ready**: Fully compatible with continuous integration and automated test running processes.
 - ✅ **Optional HTML-first mode**: Working on UI-heavy code? Write tests in HTML, with reactive evaluation and mock interactions!
 
 ## Installation

--- a/docs/run/node/README.md
+++ b/docs/run/node/README.md
@@ -123,7 +123,7 @@ npx htest tests --ci
 ```
 
 This mode:
-- Disables colors and interactive elements
+- Disables interactive elements
 - Outputs in a format optimized for CI logging
 - Exits with code `1` if any tests fail
 

--- a/docs/run/node/README.md
+++ b/docs/run/node/README.md
@@ -113,3 +113,41 @@ import run from "../node_modules/htest.dev/src/js/run.js";
 
 run("tests/*.js");
 ```
+
+## Running in CI environments
+
+For continuous integration environments, you can use the `--ci` flag to optimize output for CI systems:
+
+```sh
+npx htest tests --ci
+```
+
+This mode:
+- Disables colors and interactive elements
+- Outputs in a format optimized for CI logging
+- Exits with code `1` if any tests fail
+
+You can use it in your `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "test": "npx htest tests --ci"
+  }
+}
+```
+
+Example GitHub Actions workflow:
+
+```yaml
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm install
+      - run: npm test
+```

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,6 +34,10 @@ export async function getConfig (glob = CONFIG_GLOB) {
  * Run tests via a CLI command
  * First argument is the location to look for tests (defaults to the current directory)
  * Second argument is the test path (optional)
+ * 
+ * Supported flags:
+ * --ci    Run in continuous integration mode (disables interactive features)
+ * 
  * @param {object} [options] Same as `run()` options, but command line arguments take precedence
  */
 export default async function cli (options = {}) {
@@ -43,6 +47,14 @@ export default async function cli (options = {}) {
 	}
 
 	let argv = process.argv.slice(2);
+
+	// Check for “--ci” flag
+	let ciIndex = argv.indexOf("--ci");
+	if (ciIndex !== -1) {
+		// Remove “--ci” from args
+		argv.splice(ciIndex, 1);
+		options.ci = true;
+	}
 
 	let location = argv[0];
 

--- a/src/run.js
+++ b/src/run.js
@@ -19,6 +19,11 @@ export default function run (test, options = {}) {
 		options.env = "auto";
 	}
 
+	if (options.ci) {
+		// Disable rich output (in case of failed tests) in CI mode
+		options.format = "plain";
+	}
+
 	if (typeof options.env === "string") {
 		import(`./env/${ options.env }.js`)
 			.then(m => run(test, {...options, env: m.default}))

--- a/src/run.js
+++ b/src/run.js
@@ -19,11 +19,6 @@ export default function run (test, options = {}) {
 		options.env = "auto";
 	}
 
-	if (options.ci) {
-		// Disable rich output (in case of failed tests) in CI mode
-		options.format = "plain";
-	}
-
 	if (typeof options.env === "string") {
 		import(`./env/${ options.env }.js`)
 			.then(m => run(test, {...options, env: m.default}))


### PR DESCRIPTION
via the `--ci` flag

The diff in `src/env/node.js` is a bit messy, but I only added the check for the CI mode and moved the old code to the `else` branch.

When some of the tests fail, we exit with code `1` and output some additional info that looks like this:
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/8fe43f55-bdd4-4b27-a519-686e01cb2830" />
