### PR TITLE
Fix the HTML mode

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -1,7 +1,10 @@
 import BubblingEventTarget from "./BubblingEventTarget.js";
 import format, { stripFormatting } from "../format-console.js";
 import { delay, formatDuration, interceptConsole, pluralize, stringify, formatDiff } from "../util.js";
-import { diffChars } from "diff";
+import { IS_NODEJS } from "../util.js";
+
+// Make the diff package available both in Node.js and the browser
+const { diffChars } = await import(IS_NODEJS ? "diff" : "https://cdn.jsdelivr.net/npm/diff@7.0.0/lib/index.es6.js");
 
 /**
  * Represents the result of a test or group of tests.

--- a/src/env/auto.js
+++ b/src/env/auto.js
@@ -1,9 +1,7 @@
+import { IS_NODEJS } from "../util.js";
+
 /**
  * Resolves to one of the existing environments based on heuristics
  */
-
-// Are we in Node.js?
-const IS_NODEJS = typeof process === "object" && process?.versions?.node;
-
 const env = await import(IS_NODEJS ? "./node.js" : "./console.js").then(m => m.default);
 export default env;

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,11 @@
 import * as objects from "./objects.js";
 
 /**
+ * Whether we are in Node.js
+ */
+export const IS_NODEJS = typeof process === "object" && process?.versions?.node;
+
+/**
  * Determine the internal JavaScript [[Class]] of an object.
  * @param {*} value - Value to check
  * @returns {string}


### PR DESCRIPTION
- Move `IS_NODEJS` to `util`
- Make the `diff` package available both in Node.js and the browser

After adding the `diff` package to improve the fail screen, we broke the HTML mode (see the [Color.js testsuite](https://colorjs.io/test/) as an example): it fails with the `Uncaught (in promise) TypeError: Failed to resolve module specifier "diff". Relative references must start with either "/", "./", or "../"` error. This PR fixes it.