### PR TITLE
Fix totals in the HTML mode

### DIFF
--- a/src/html/harness.js
+++ b/src/html/harness.js
@@ -33,8 +33,8 @@ function runSelected (names) {
 				return;
 			}
 
-			totals.pass += +doc.querySelector("body > nav .count-pass .count").textContent;
-			totals.fail += +doc.querySelector("body > nav .count-fail .count").textContent;
+			totals.pass += +doc.body.style.getPropertyValue("--pass");
+			totals.fail += +doc.body.style.getPropertyValue("--fail");
 		});
 
 		let totalsEl = document.querySelector("h1 + .totals") || create({className: "totals", after: document.querySelector("h1")});


### PR DESCRIPTION
Number of passed and failed tests are in the `content` property of the `::before` pseudo element, not in `textContent`, so the totals are not updated. Since we already have the `--pass` and `--fail` custom properties on `<body>`, we can use them to update the totals.