### PR TITLE
Another iteration on setup and teardown

### DIFF
--- a/docs/define/README.md
+++ b/docs/define/README.md
@@ -16,6 +16,10 @@ You can access the inherited property via `this.parent` when re-defining either 
 | [`run`](#run) | Function | The code to run. |
 | [`args`](#args) | Array | Arguments to pass to the running function. |
 | [`arg`](#args) | Any | A single argument to pass to the running function. |
+| [`before`](#setup-teardown) | Function | Code to run before the test. |
+| [`after`](#setup-teardown) | Function | Code to run after the test. |
+| [`beforeAll`](#setup-teardown) | Function | Code to run before all tests in the group. |
+| [`afterAll`](#setup-teardown) | Function | Code to run after all tests in the group. |
 | [`data`](#data) | Object | Data that will be accessible to the running function as `this.data`. |
 | [`name`](#name) | String or Function | A string that describes the test. |
 | [`getName`](#name) | Function | A function that generates the test name dynamically. |
@@ -45,6 +49,17 @@ If you pass a single argument, it will be converted to an array.
 If both `arg` and `args` are defined, `arg` wins.
 
 `arg` is internally rewritten to `args`, so in any functions that run with the current test as their context you can just use `this.args` without having to explicitly check for `this.arg`
+
+### Setup and teardown (`before`, `after`, `beforeAll`, `afterAll`) { #setup-teardown }
+
+Some tests require setup and teardown code that runs before and after the test or group of tests, such as setting up DOM fixtures.
+
+Functions `before` and `after` define the code to run before and after *each test* if it is not [skipped](#skip).
+Functions `beforeAll` and `afterAll` define the code to run before and after *all tests in the group* regardless of whether they are skipped.
+
+All of these functions can be either sync or async.
+
+You can define a single `before` or `after` function on a parent or ancestor and differentiate child tests via [`args`](#args) and [`data`](#data).
 
 ### `data`: Context parameters
 
@@ -215,4 +230,3 @@ Often, we have written tests for parts of the API that are not yet implemented.
 It doesn't make sense to remove these tests, but they should also not be making the testsuite fail.
 You can set `skip: true` to skip a test.
 The number of skipped tests will be shown separately.
-

--- a/docs/define/README.md
+++ b/docs/define/README.md
@@ -16,8 +16,8 @@ You can access the inherited property via `this.parent` when re-defining either 
 | [`run`](#run) | Function | The code to run. |
 | [`args`](#args) | Array | Arguments to pass to the running function. |
 | [`arg`](#args) | Any | A single argument to pass to the running function. |
-| [`before`](#setup-teardown) | Function | Code to run before the test. |
-| [`after`](#setup-teardown) | Function | Code to run after the test. |
+| [`beforeEach`](#setup-teardown) | Function | Code to run before each test. |
+| [`afterEach`](#setup-teardown) | Function | Code to run after each test. |
 | [`beforeAll`](#setup-teardown) | Function | Code to run before all tests in the group. |
 | [`afterAll`](#setup-teardown) | Function | Code to run after all tests in the group. |
 | [`data`](#data) | Object | Data that will be accessible to the running function as `this.data`. |
@@ -50,16 +50,16 @@ If both `arg` and `args` are defined, `arg` wins.
 
 `arg` is internally rewritten to `args`, so in any functions that run with the current test as their context you can just use `this.args` without having to explicitly check for `this.arg`
 
-### Setup and teardown (`before`, `after`, `beforeAll`, `afterAll`) { #setup-teardown }
+### Setup and teardown (`beforeEach`, `afterEach`, `beforeAll`, `afterAll`) { #setup-teardown }
 
 Some tests require setup and teardown code that runs before and after the test or group of tests, such as setting up DOM fixtures.
 
-Functions `before` and `after` define the code to run before and after *each test* if it is not [skipped](#skip).
+Functions `beforeEach` and `afterEach` define the code to run before and after *each test* if it is not [skipped](#skip).
 Functions `beforeAll` and `afterAll` define the code to run before and after *all tests in the group* regardless of whether they are skipped.
 
 All of these functions can be either sync or async.
 
-You can define a single `before` or `after` function on a parent or ancestor and differentiate child tests via [`args`](#args) and [`data`](#data).
+You can define a single `beforeEach` or `afterEach` function on a parent or ancestor and differentiate child tests via [`args`](#args) and [`data`](#data).
 
 ### `data`: Context parameters
 

--- a/src/classes/Test.js
+++ b/src/classes/Test.js
@@ -33,15 +33,12 @@ export default class Test {
 		// Inherit properties from parent
 		// This works recursively because the parent constructor runs before its children
 		if (this.parent) {
-			for (let prop of ["setup", "run", "teardown", "map", "check", "getName", "args", "expect", "skip"]) {
+			for (let prop of ["before", "run", "after", "map", "check", "getName", "args", "expect", "skip"]) {
 				if (!(prop in this) && prop in this.parent) {
 					this[prop] = this.parent[prop];
 				}
 			}
 		}
-
-		this.setup ??= () => {};
-		this.teardown ??= () => {};
 
 		if (!this.check) {
 			this.check = check.equals;

--- a/src/classes/Test.js
+++ b/src/classes/Test.js
@@ -33,7 +33,7 @@ export default class Test {
 		// Inherit properties from parent
 		// This works recursively because the parent constructor runs before its children
 		if (this.parent) {
-			for (let prop of ["before", "run", "after", "map", "check", "getName", "args", "expect", "skip"]) {
+			for (let prop of ["beforeEach", "run", "afterEach", "map", "check", "getName", "args", "expect", "skip"]) {
 				if (!(prop in this) && prop in this.parent) {
 					this[prop] = this.parent[prop];
 				}

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -142,20 +142,24 @@ export default class TestResult extends BubblingEventTarget {
 
 		this.tests = this.test.tests?.map(t => new TestResult(t, this, childOptions));
 
-		delay(1).then(() => {
-			if (this.test.isTest) {
-				if (this.test.skip) {
-					this.skip();
+		delay(1)
+			.then(() => Promise.resolve(this.test.beforeAll?.()))
+			.then(() => {
+				if (this.test.isTest) {
+					if (this.test.skip) {
+						this.skip();
+					}
+					else {
+						Promise.resolve(this.test.before?.())
+							.then(() => this.run())
+							.finally(() => this.test.after?.());
+					}
 				}
-				else {
-					Promise.resolve(this.test.setup())
-						.then(() => this.run())
-						.finally(() => this.test.teardown());
-				}
-			}
 
-			this.tests?.forEach(t => t.runAll());
-		});
+				this.tests?.forEach(t => t.runAll());
+
+				this.finished.then(() => this.test.afterAll?.());
+			});
 
 		return this;
 	}

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -143,7 +143,7 @@ export default class TestResult extends BubblingEventTarget {
 		this.tests = this.test.tests?.map(t => new TestResult(t, this, childOptions));
 
 		delay(1)
-			.then(() => Promise.resolve(this.test.beforeAll?.()))
+			.then(() => this.test.beforeAll?.())
 			.then(() => {
 				if (this.test.isTest) {
 					if (this.test.skip) {

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -150,9 +150,9 @@ export default class TestResult extends BubblingEventTarget {
 						this.skip();
 					}
 					else {
-						Promise.resolve(this.test.before?.())
+						Promise.resolve(this.test.beforeEach?.())
 							.then(() => this.run())
-							.finally(() => this.test.after?.());
+							.finally(() => this.test.afterEach?.());
 					}
 				}
 


### PR DESCRIPTION
- Rename: `setup` → `beforeEach`, `teardown` → `afterEach`
- Add support for `beforeAll` and `afterAll` (not inheritable)
- Simplify the code: no need for dummy functions; simply envoke them if they are defined
- Add some docs