### PR TITLE
Fix bugs with setup and teardown

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -84,6 +84,11 @@ export default class TestResult extends BubblingEventTarget {
 	 */
 	async run () {
 		this.messages = await interceptConsole(async () => {
+			if (!this.parent) {
+				// We are running the test in isolation, so we need to run beforeAll (if it exists)
+				await this.test.beforeAll?.();
+			}
+
 			await this.test.beforeEach?.();
 
 			let start = performance.now();
@@ -102,6 +107,11 @@ export default class TestResult extends BubblingEventTarget {
 			}
 			finally {
 				await this.test.afterEach?.();
+
+				if (!this.parent) {
+					// We are running the test in isolation, so we need to run afterAll
+					await this.test.afterAll?.();
+				}
 			}
 		});
 


### PR DESCRIPTION
- Maintain proper sequencing when hooks (`beforeEach`/`afterEach`, `beforeAll`/`afterAll`) are used
- Fall back to parallel execution (using `Promise.all`) when no hooks exist

Now, we might end up (I already was bit by this bug) calling `afterAll` before `afterEach` for some tests. In most cases, `beforeEach` for all tests is called before the first test runs. There are probably some more issues we haven't encountered yet. This PR should fix those bugs.