### PR TITLE
[HTML mode] Improve rendering of nested objects

### DIFF
--- a/src/html/util.js
+++ b/src/html/util.js
@@ -78,6 +78,14 @@ export function output (obj) {
 			if (typeof obj === "string") {
 				return obj;
 			}
+
+			// Handle nested objects
+			if (obj && typeof obj === "object") {
+				let entries = Object.entries(obj).map(([key, value]) =>
+					`${ key }: ${ output(value) }`,
+				);
+				return "{ " + entries.join(", ") + " }";
+			}
 		},
 	});
 }


### PR DESCRIPTION
When `args` is an object containing nested objects, we have the following output in the HTML mode (mind commas at the beginning and end of the string):
<img width="422" alt="image" src="https://github.com/user-attachments/assets/10039aa7-7a99-423d-8b5f-9cb6cb9e0561" />

With this PR, the output is fixed:
<img width="424" alt="SCR-20250125-onvo" src="https://github.com/user-attachments/assets/b256e129-3e99-4eb1-aee2-6f221fe412ca" />
