### PR TITLE
Don't intercept console when not in Node

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -199,9 +199,11 @@ export async function interceptConsole (fn) {
 	let originalConsole = {};
 	let messages = [];
 
-	for (let method of methods) {
-		originalConsole[method] = console[method];
-		console[method] = (...args) => messages.push({args, method});
+	if (IS_NODEJS) {
+		for (let method of methods) {
+			originalConsole[method] = console[method];
+			console[method] = (...args) => messages.push({args, method});
+		}
 	}
 
 	fn = fn();


### PR DESCRIPTION
Otherwise, when running JS-first tests in the browser, we lose all the console messages produced by the tests.