### PR TITLE
[HTML] Add support for skipped tests

### DIFF
--- a/htest.css
+++ b/htest.css
@@ -7,9 +7,11 @@
 	--color-dark: hsl(200, 50%, 40%);
 	--color-pass: hsl(80, 70%, 75%);
 	--color-fail: hsl(0, 70%, 90%);
+	--color-skipped: hsl(0, 0%, 85%);
 	--color-error: hsl(0, 70%, 70%);
 	--color-pass-darker: hsl(80, 70%, 40%);
 	--color-fail-darker: hsl(0, 70%, 48%);
+	--color-skipped-darker: hsl(0, 0%, 48%);
 	--color-error-darker: hsl(0, 70%, 40%);
 	--font-base: system-ui, "Helvetica Neue", "Segoe UI", sans-serif;
 }
@@ -78,6 +80,11 @@ h1 {
 	--dark-color: var(--color-fail-darker);
 }
 
+.skipped, .count-skipped {
+	--color: var(--color-skipped);
+	--dark-color: var(--color-skipped-darker);
+}
+
 .error {
 	--color: var(--color-error);
 	--dark-color: var(--color-error-darker);
@@ -89,7 +96,7 @@ html:not(.index) {
 		max-width: calc(100vw - 5em);
 		padding-top: 2em;
 
-		counter-reset: passed var(--pass, 0) failed var(--fail, 0);
+		counter-reset: passed var(--pass, 0) failed var(--fail, 0) skipped var(--skipped, 0);
 	}
 
 	& body > nav {
@@ -126,7 +133,8 @@ html:not(.index) {
 		}
 
 		& .count-fail,
-		& .count-pass {
+		& .count-pass,
+		& .count-skipped {
 			flex-shrink: 0;
 			min-width: 0;
 			align-items: center;
@@ -152,8 +160,15 @@ html:not(.index) {
 			}
 		}
 
+		.count-skipped {
+			.count::before {
+				content: counter(skipped);
+			}
+		}
+
 		.count-fail:is(.no-failed *),
-		.count-pass:is(.no-passed *) {
+		.count-pass:is(.no-passed *),
+		.count-skipped:is(.no-skipped *) {
 			display: none;
 		}
 
@@ -197,11 +212,23 @@ html:not(.index) {
 			}
 		}
 
+		& .count-skipped {
+			flex-grow: var(--skipped, 1);
+
+			& .count::after {
+				content: "skipped";
+			}
+		}
+
 		&[style*="--fail:0;"] .count-fail {
 			display: none;
 		}
 
 		&[style*="--pass:0;"] .count-pass {
+			display: none;
+		}
+
+		&[style*="--skipped:0;"] .count-skipped {
 			display: none;
 		}
 	}
@@ -310,18 +337,18 @@ table.reftest {
 		}
 	}
 
-	&.ignore tr,
-	& tr.ignore {
-		--append: " (Ignored)";
+	&.skipped tr,
+	& tr.skipped {
+		--append: " (Skipped)";
 
 		&.fail {
-			--append: " (Known failure, ignored)"
+			--append: " (skipped)"
 		}
 	}
 
 	& tr[title],
-	&.ignore tr,
-	& tr.ignore {
+	&.skipped tr,
+	& tr.skipped {
 		& td {
 			padding-top: 1.5em;
 		}

--- a/src/html/harness.js
+++ b/src/html/harness.js
@@ -24,7 +24,7 @@ function runSelected (names) {
 	});
 
 	function updateTotals () {
-		let totals = {pass: 0, fail: 0};
+		let totals = {pass: 0, fail: 0, skipped: 0};
 
 		tests.forEach(iframe => {
 			let doc = iframe.contentDocument;
@@ -35,11 +35,12 @@ function runSelected (names) {
 
 			totals.pass += +doc.body.style.getPropertyValue("--pass");
 			totals.fail += +doc.body.style.getPropertyValue("--fail");
+			totals.skipped += +doc.body.style.getPropertyValue("--skipped");
 		});
 
 		let totalsEl = document.querySelector("h1 + .totals") || create({className: "totals", after: document.querySelector("h1")});
 
-		totalsEl.innerHTML = `<strong>${totals.pass}</strong> passing, <strong>${totals.fail}</strong> failing of ${totals.pass + totals.fail} total`;
+		totalsEl.innerHTML = `<strong>${totals.pass}</strong> passing, <strong>${totals.fail}</strong> failing, <strong>${totals.skipped}</strong> skipped of ${totals.pass + totals.fail + totals.skipped} total`;
 	}
 }
 

--- a/src/html/reftest.js
+++ b/src/html/reftest.js
@@ -233,11 +233,13 @@ export default class RefTest {
 
 	static updateResults () {
 		this.results = {
-			pass: $$("table.reftest:not(.ignore) tr.pass:not(.ignore)"),
-			fail: $$("table.reftest:not(.ignore) tr.fail:not(.ignore)"),
+			pass: $$("table.reftest:not(.skipped) tr.pass:not(.skipped)"),
+			fail: $$("table.reftest:not(.skipped) tr.fail:not(.skipped)"),
+			skipped: $$("table.reftest tr.skipped"),
 			current: {
 				pass: -1,
 				fail: -1,
+				skipped: -1,
 			},
 			// interactive: $$("table.reftest tr.interactive")
 		};
@@ -245,14 +247,16 @@ export default class RefTest {
 		let detail = {
 			pass: this.results.pass.length,
 			fail: this.results.fail.length,
+			skipped: this.results.skipped.length,
 		};
 
 		document.body.style.setProperty("--pass", detail.pass);
 		document.body.style.setProperty("--fail", detail.fail);
+		document.body.style.setProperty("--skipped", detail.skipped);
 
 		document.body.classList.toggle("no-passed", detail.pass === 0);
 		document.body.classList.toggle("no-failed", detail.fail === 0);
-
+		document.body.classList.toggle("no-skipped", detail.skipped === 0);
 		// $(".count-interactive", RefTest.nav).textContent = RefTest.results.interactive.length;
 
 		document.dispatchEvent(new CustomEvent("testresultsupdate", {detail}));

--- a/src/html/testpage.js
+++ b/src/html/testpage.js
@@ -138,7 +138,7 @@ let nav = create({
 			href: "index.html",
 			target: "_top",
 		} : undefined,
-		...["fail", "pass"].map(type => {
+		...["fail", "pass", "skipped"].map(type => {
 			return {
 				className: "count-" + type,
 				contents: [

--- a/src/render.js
+++ b/src/render.js
@@ -69,6 +69,9 @@ export default function render (test) {
 			let tr = testRows.get(target.test);
 			tr.cells[1].textContent = output(target.actual);
 			tr.classList.add(target.pass ? "pass" : "fail");
+			if (target.test.skip) {
+				tr.classList.add("skipped");
+			}
 			tr.dataset.time = formatDuration(target.timeTaken);
 		}
 	});


### PR DESCRIPTION
- Rename class `ignore` to `skipped` to be even with the JS mode

Here is how it looks:

<img width="375" alt="image" src="https://github.com/user-attachments/assets/299ba008-a34b-44bb-a3c0-4ddbeabd18fd" />

<img width="1534" alt="image" src="https://github.com/user-attachments/assets/b1dd4ee7-d4a3-47af-b264-a30ee76fc11a" />
