### PR TITLE
[HTML mode] Make test isolation and the navigation between individual tests work again

### DIFF
--- a/htest.css
+++ b/htest.css
@@ -323,6 +323,7 @@ table.reftest {
 		position: relative;
 		margin: .4em 0;
 		background: var(--color);
+		scroll-margin-top: 2.5rem;
 
 		&[data-time]::after {
 			content: attr(data-time);

--- a/htest.css
+++ b/htest.css
@@ -292,7 +292,8 @@ table.reftest {
 		display: flex;
 	}
 
-	& tbody > tr {
+	& tbody > tr,
+	& > tr {
 		border: 1px solid hsla(0, 0%, 0%, .1);
 
 		&:not([class]) {

--- a/src/html/testpage.js
+++ b/src/html/testpage.js
@@ -59,7 +59,7 @@ loadCSS("https://unpkg.com/tippy.js@1.3.0/dist/tippy.css");
 await ready();
 
 // Add ids to all tests
-$$(`.reftest > tbody > tr`).forEach((test, i) => {
+$$(`.reftest > tbody > tr, .reftest > tr`).forEach((test, i) => {
 	if (!test.id) {
 		test.id = idify(test.title) || "test-" + (i + 1);
 	}
@@ -75,7 +75,7 @@ let hashchanged = evt => {
 		}
 
 		let isSection = target.matches("body > section");
-		let isTest = target.matches(".reftest > tbody > tr");
+		let isTest = target.matches(".reftest > tbody > tr, .reftest > tr");
 
 		if (isSection || isTest) {
 			if (evt) {
@@ -95,7 +95,7 @@ let hashchanged = evt => {
 			}
 
 			if (isTest) {
-				for (let test of $$(`.reftest > tbody > tr`)) {
+				for (let test of $$(`.reftest > tbody > tr, .reftest > tr`)) {
 					if (test.id !== target.id) {
 						test.remove();
 					}
@@ -193,7 +193,7 @@ function loadCSS (url) {
 // Isolate specific test
 document.addEventListener("dblclick", evt => {
 	if (evt.altKey) {
-		let test = evt.target.closest(".reftest > tbody > tr");
+		let test = evt.target.closest(".reftest > tbody > tr, .reftest > tr");
 
 		if (test) {
 			location.hash = test.id;

--- a/src/html/testpage.js
+++ b/src/html/testpage.js
@@ -126,7 +126,7 @@ hashchanged();
 window.addEventListener("hashchange", hashchanged);
 
 // Add div for counter at the end of body
-let nav = create({
+RefTest.nav = create({
 	tag: "nav",
 	inside: document.body,
 	contents: [

--- a/src/html/testpage.js
+++ b/src/html/testpage.js
@@ -61,7 +61,8 @@ await ready();
 // Add ids to all tests
 $$(`.reftest > tbody > tr, .reftest > tr`).forEach((test, i) => {
 	if (!test.id) {
-		test.id = idify(test.title) || "test-" + (i + 1);
+		let id = idify(test.title);
+		test.id = id + (id ? "-" : "") + "test-" + (i + 1);
 	}
 });
 


### PR DESCRIPTION
- Add some margin to make the scrolled-into-view test fully visible
- Consider as a test not only direct children of `tbody` but also direct children of the reftest table itself (the exact case when we render JS-first tests)
- Generate unique ids (sometimes, tests might have the same name, so we can't simply use them as ids). Without unique ids, the isolation feature doesn't work as expected

<img width="853" alt="image" src="https://github.com/user-attachments/assets/1a0a2538-a816-43a5-aac5-486686b01554" />
