### PR TITLE
[HTML] On click, show details for failing tests in the console

### DIFF
--- a/htest.css
+++ b/htest.css
@@ -320,7 +320,7 @@ table.reftest {
 		border-right: 1px solid hsla(0, 0%, 0%, .1);
 	}
 
-	& td[data-error-stack] {
+	& td.details {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;

--- a/src/render.js
+++ b/src/render.js
@@ -7,6 +7,7 @@ import TestResult from "./classes/TestResult.js";
 import RefTest from "./html/reftest.js";
 import { create, output } from "./html/util.js";
 import { formatDuration } from "./util.js";
+import format from "./format-console.js";
 
 export default function render (test) {
 	let root = new Test(test);
@@ -82,7 +83,7 @@ export default function render (test) {
 			}
 			else if (!target.pass) {
 				cell.classList.add("details");
-				cell.onclick = () => console.log(target.details.join("\n"));
+				cell.onclick = () => console.log(target.details.map(format).join("\n"));
 			}
 			tr.dataset.time = formatDuration(target.timeTaken);
 		}

--- a/src/render.js
+++ b/src/render.js
@@ -71,7 +71,6 @@ export default function render (test) {
 			let cell = tr.cells[1];
 			if (error) {
 				cell.dataset.errorStack = error.stack;
-				cell.onclick = () => console.log(error.stack);
 				cell.textContent = error;
 			}
 			else {
@@ -81,10 +80,13 @@ export default function render (test) {
 			if (target.test.skip) {
 				tr.classList.add("skipped");
 			}
+			else if (!target.pass) {
+				cell.classList.add("details");
+				cell.onclick = () => console.log(target.details.join("\n"));
+			}
 			tr.dataset.time = formatDuration(target.timeTaken);
 		}
 	});
 
 	result.runAll();
 }
-


### PR DESCRIPTION
Otherwise, there is no way to understand why error- and time-based tests fail.

With the change, a message in the console also shows diff:
<img width="230" alt="image" src="https://github.com/user-attachments/assets/b0ad113c-3c52-42ca-865e-f38bb161aa32" />
