### PR TITLE
[HTML] Don't render the expected value for skipped and error-based tests

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -36,7 +36,7 @@ export default function render (test) {
 							contents: [
 								{tag: "td", textContent: t2.args?.map(a => output(a)).join(", ") },
 								{tag: "td"},
-								{tag: "td", textContent: output(t2.expect) },
+								{tag: "td", textContent: !t2.skip && t2.throws === undefined ? output(t2.expect) : "" },
 							],
 						});
 


### PR DESCRIPTION
It makes the UI cleaner and looks less confusing when we expect a test to throw, but the column with the expected value is not empty. Now, when we default to `this.args[0]`, every test has the `expect` field.

### Before

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/ae0dd874-d4ce-4eac-afb8-b9fbc84e0ccb" />

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/956800c1-a2bf-4295-8600-81b39793828d" />


### After

<img width="1271" alt="image" src="https://github.com/user-attachments/assets/b159ddc9-79ac-448c-90f6-113483da295c" />

<img width="1271" alt="image" src="https://github.com/user-attachments/assets/a7fe155a-376e-4ba8-8214-052833f645fe" />
