### PR TITLE
Respect the `verbose` option when printing out results

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -390,9 +390,10 @@ ${ this.error.stack }`);
 	 * @returns {string}
 	 */
 	getResult (o) {
-		let color = this.pass ? "green" : "red";
+		let color = this.pass ? "green" : this.skip ? "yellow" : "red";
+		let label = this.pass ? "PASS" : this.skip ? "SKIP" : "FAIL";
 		let ret = [
-			`<b><bg ${color}><c white> ${ this.pass ? "PASS" : "FAIL" } </c></bg></b>`,
+			`<b><bg ${color}><c white> ${ label } </c></bg></b>`,
 			`<c light${color}>${this.name ?? "(Anonymous)"}</c>`,
 		].join(" ");
 

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -484,7 +484,7 @@ ${ this.error.stack }`);
 			ret = new String(ret);
 
 			if (this.tests) {
-				ret.children = this.tests.filter(t => t.stats.fail + t.stats.pending + t.stats.skipped + t.stats.messages > 0)
+				ret.children = this.tests.filter(t => (t.stats.fail + t.stats.pending + t.stats.skipped + t.stats.messages > 0) || o?.verbose)
 				                     .flatMap(t => t.toString(o)).filter(Boolean);
 			}
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,10 +34,11 @@ export async function getConfig (glob = CONFIG_GLOB) {
  * Run tests via a CLI command
  * First argument is the location to look for tests (defaults to the current directory)
  * Second argument is the test path (optional)
- * 
+ *
  * Supported flags:
- * --ci    Run in continuous integration mode (disables interactive features)
- * 
+ * --ci         Run in continuous integration mode (disables interactive features)
+ * --verbose    Verbose output (show all tests, not just failed, skipped, or tests with intercepted console messages)
+ *
  * @param {object} [options] Same as `run()` options, but command line arguments take precedence
  */
 export default async function cli (options = {}) {
@@ -48,12 +49,13 @@ export default async function cli (options = {}) {
 
 	let argv = process.argv.slice(2);
 
-	// Check for “--ci” flag
-	let ciIndex = argv.indexOf("--ci");
-	if (ciIndex !== -1) {
-		// Remove “--ci” from args
-		argv.splice(ciIndex, 1);
-		options.ci = true;
+	const flags = ["ci", "verbose"];
+	for (let flag of flags) {
+		let flagIndex = argv.indexOf("--" + flag);
+		if (flagIndex !== -1) {
+			argv.splice(flagIndex, 1); // remove the flag from args
+			options[flag] = true;
+		}
 	}
 
 	let location = argv[0];

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -131,12 +131,12 @@ export default {
 	done (result, options, event, root) {
 		if (options.ci) {
 			if (root.stats.pending === 0) {
-				if (root.stats.fail > 0) {
+				if (root.stats.fail > 0 || options.verbose) {
 					let messages = root.toString(options);
 					let tree = getTree(messages).toString();
 					tree = format(tree);
 
-					console.error(tree);
+					console[root.stats.fail > 0 ? "error" : "log"](tree);
 					process.exit(1);
 				}
 


### PR DESCRIPTION
For now, even if we specify that option, groups with all passed tests won’t be shown. In CI/CD, this option is not respected even partially. Rel to #7 and #96.

With the changes, one can enable verbose output via the `--verbose` CLI argument.

I also changed the formatting of skipped tests. For now, they are formatted as failed. Unfortunately, we don’t have many ANSI colors to choose from, so I decided to stick with yellow (I also tried black, as it was the closest to gray, but I thought the final look wasn't decent enough).

As a result of all these changes, we can get (when testing `color.js`):

<img width="626" alt="image" src="https://github.com/user-attachments/assets/3d935254-12f4-45d0-9841-7ae2f07e4d86" />

Running tests with both options (`ci` and `verbose`) enabled allows us to (at least partially) address use cases mentioned by @kleinfreund in #96.