### PR TITLE
Stringify intercepted messages before printing them out

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -464,7 +464,7 @@ ${ this.error.stack }`);
 	 */
 	getMessages (o = {}) {
 		let ret = new String("<c yellow><b><i>(Messages)</i></b></c>");
-		ret.children = this.messages.map(m => `<dim>(${ m.method })</dim> ${ m.args.join(" ") }`);
+		ret.children = this.messages.map(m => `<dim>(${ m.method })</dim> ${ m.args.map(a => stringify(a)).join(" ") }`);
 
 		return o?.format === "rich" ? ret : stripFormatting(ret);
 	}


### PR DESCRIPTION
Fixes the issue when logging objects. For now, we get `[object Object]` in such cases. [Found](https://github.com/htest-dev/htest/issues/96#issuecomment-2984253506) by @kleinfreund.