### PR TITLE
Fix afterAll skipped in --ci

### DIFF
--- a/src/env/node.js
+++ b/src/env/node.js
@@ -391,7 +391,7 @@ export default {
 
 				console[root.stats.fail > 0 ? "error" : "log"](tree);
 
-				process.exit(root.stats.fail > 0 ? 1 : 0);
+				process.exitCode = root.stats.fail > 0 ? 1 : 0;
 			}
 			return;
 		}

--- a/tests/run.js
+++ b/tests/run.js
@@ -20,9 +20,35 @@ export default {
 				},
 				{
 					name: "run() returning a promise",
-					run: () => new Promise(resolve => setInterval(() => resolve("foo"), 100)),
+					run: () => new Promise(resolve => setTimeout(() => resolve("foo"), 100)),
 				},
 			],
+		},
+		{
+			name: "afterAll runs in --ci mode (issue #168)",
+			skip: typeof globalThis.process === "undefined",
+			async run () {
+				let { spawnSync } = await import("node:child_process");
+				let { writeFileSync, rmSync } = await import("node:fs");
+				let { tmpdir } = await import("node:os");
+				let { join } = await import("node:path");
+
+				let fixture = join(tmpdir(), "htest-168.js");
+				writeFileSync(
+					fixture,
+					`export default { async afterAll () { await new Promise(r => setTimeout(r, 50)); process.stderr.write("[test] afterAll ran"); }, tests: [{ run: () => 1, expect: 1 }] };`,
+				);
+
+				let { stderr } = spawnSync(
+					process.execPath,
+					[join(process.cwd(), "bin/htest.js"), fixture, "--ci"],
+					{ encoding: "utf8" },
+				);
+				rmSync(fixture);
+
+				return stderr.includes("[test] afterAll ran");
+			},
+			expect: true,
 		},
 		{
 			name: "Aborting",


### PR DESCRIPTION
Closes #168.

In `--ci` (non-interactive) mode, `process.exit()` fires synchronously the moment `stats.pending === 0`, before the trailing `.finally(() => afterAll())` microtask in `TestResult#runAll` can resolve. As a result, `afterAll` hooks never run.

## Fix

In `src/env/node.js`: `process.exit(N)` → `process.exitCode = N`. Setting the exit code lets the event loop drain — Node runs the queued `.finally(afterAll)` microtask, then exits with the set code because nothing else keeps it alive.

No changes to `src/classes/TestResult.js`. `result.finished` and `afterAll` keep their existing meanings ([per the discussion above](https://github.com/htest-dev/htest/pull/170#issuecomment-4809591566)).

## Drive-by

`tests/run.js` had a pre-existing leak: `setInterval(() => resolve("foo"), 100)` was used where `setTimeout` was intended, leaving a recurring 100 ms timer that's never cleared. `process.exit()` masked it; `process.exitCode` exposes it (the runner would hang). One-line fix: `setInterval` → `setTimeout`.

## Out of scope

Bottom-up `afterAll` ordering for nested groups (which an earlier draft of this PR also addressed via `TestResult.js` changes) — tracked separately as #178.

## Test plan

- [x] All 119 existing tests pass
- [x] Repro from #168 (tmp-dir cleanup in `--ci`) works
- [x] New regression test in `tests/run.js` (spawns `htest --ci` on a fixture with async `afterAll`, asserts cleanup output reached stderr)
