### PR TITLE
Fix ERR_IMPORT_ATTRIBUTE_MISSING for JSON in a test's module graph

### DIFF
--- a/src/env/node.js
+++ b/src/env/node.js
@@ -305,7 +305,11 @@ export default {
 					resolved = { ...resolved, url: baseUrl.href, shortCircuit: true };
 				}
 
-				loadedFiles.add(resolved.url);
+				// Modules resolved with import attributes, e.g. `with { type: "json" }`, hold data rather
+				// than tests, and cannot be re-imported below without repeating those attributes.
+				if (Object.keys(context.importAttributes).length === 0) {
+					loadedFiles.add(resolved.url);
+				}
 
 				return resolved;
 			},

--- a/tests/run.js
+++ b/tests/run.js
@@ -51,6 +51,36 @@ export default {
 			expect: true,
 		},
 		{
+			name: "JSON in a test's module graph loads (issue #181)",
+			description: "Import attributes cannot be replayed, so such modules must not be re-imported for file tagging.",
+			skip: typeof globalThis.process === "undefined",
+			async run () {
+				let { spawnSync } = await import("node:child_process");
+				let { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+				let { tmpdir } = await import("node:os");
+				let { join } = await import("node:path");
+
+				let dir = mkdtempSync(join(tmpdir(), "htest-181-"));
+				writeFileSync(join(dir, "data.json"), `{ "value": 42 }`);
+				writeFileSync(
+					join(dir, "test.mjs"),
+					`import data from "./data.json" with { type: "json" };\nexport default { tests: [{ run: () => data.value, expect: 42 }] };`,
+				);
+
+				let { stdout, stderr } = spawnSync(
+					process.execPath,
+					[join(process.cwd(), "bin/htest.js"), join(dir, "test.mjs"), "--ci"],
+					{ encoding: "utf8" },
+				);
+				rmSync(dir, { recursive: true });
+
+				// Assert the inner test ran — an exit code of 0 also means "No tests found".
+				// On regression the crash lands in stderr, so return it instead of a bare false.
+				return stdout.includes("1/1 PASS") || stderr;
+			},
+			expect: true,
+		},
+		{
 			name: "Aborting",
 			tests: [
 				{


### PR DESCRIPTION
Closes #181.

`resolveLocation()` ends with a loop that tags each loaded module's default export with its source file. It re-imported **every** URL the resolve hook had recorded, with a bare `import(url)` — including modules resolved with import attributes, which cannot be re-imported without repeating them. Any test file whose module graph reached a JSON file crashed the process before a single test ran.

The hook now records only URLs resolved without attributes. Such modules hold data rather than tests, so the tagging loop has nothing to do with them anyway.

```js
if (Object.keys(context.importAttributes).length === 0) {
	loadedFiles.add(resolved.url);
}
```

The `deps` graph is untouched, so the JSON edge stays in the reverse dependency map.

## Verification

All three failing rows of the issue's scope table now pass — JSON imported directly by the test file, via a dependency, and via a top-level `await import()`. All three take the same path (the resolve hook sees the JSON with attributes either way), so the regression test covers the direct case only. Reverting the four lines turns it red for the right reason:

```
FAIL  JSON in a test's module graph loads (issue #181): Got string, expected boolean
Actual: "TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module ".../data.json" needs an import attribute of "type: json"…
```

`120/120 PASS`. Per-file labels on sub-tests are unchanged (`htest tests/` still labels `check.js`, `cli.js`, `data.js`, …), and the `--watch` re-run path — where the hook rewrites the URL to `?htest=N` — re-runs cleanly through the JSON dependency.

## Diff stats

Substantive lines only (blank- and comment-only changes excluded).

| File | Added | Removed |
|---|---:|---:|
| `src/env/node.js` | 3 | 1 |
| `tests/run.js` | 25 | 0 |

## Out of scope

A JSON file no longer puts its directory in the `--watch` set. Editing it never triggered a re-run either way — the watcher filters filenames by `/\.m?js$/` — so nothing is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXmFiBg3UGUMuGFXjn5Ki
